### PR TITLE
Minor Fixes

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -69,7 +69,6 @@ configure_file(
 cmaize_find_or_build_dependency(
     simde
     URL github.com/NWChemEx/SimDE
-    PRIVATE TRUE
     VERSION ${NWX_SIMDE_VERSION}
     BUILD_TARGET simde
     FIND_TARGET nwx::simde

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -32,4 +32,4 @@ packages.
 
    autoapi/friendzone/index
    module_api/index
-   C++ API <https://nwchemex.github.io/friendzone/friendzone_cxx_api/index.html>
+   C++ API <https://nwchemex.github.io/FriendZone/friendzone_cxx_api/index.html>


### PR DESCRIPTION
**Description**
Makes the SimDE dependency not private, and fixes the link to the C++ API documentation that had improper capitalization.