### PR TITLE
CMaize Workaround

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -77,6 +77,10 @@ cmaize_find_or_build_dependency(
                ENABLE_EXPERIMENTAL_FEATURES=${ENABLE_EXPERIMENTAL_FEATURES}
 )
 
+#TOOD: Replace cmaize_add_library when it supports Python
+add_library(${PROJECT_NAME} INTERFACE)
+target_link_libraries(${PROJECT_NAME} INTERFACE simde nwchem)
+
 if("${BUILD_TESTING}")
     include(CTest)
     include(nwx_pybind11)

--- a/cmake/nwchem.cmake
+++ b/cmake/nwchem.cmake
@@ -29,5 +29,6 @@ endfunction()
 
 if("${ENABLE_NWCHEM}")
     find_nwchem()
-    add_library(nwchem INTERFACE)
 endif()
+
+add_library(nwchem INTERFACE)

--- a/cmake/nwchem.cmake
+++ b/cmake/nwchem.cmake
@@ -29,4 +29,5 @@ endfunction()
 
 if("${ENABLE_NWCHEM}")
     find_nwchem()
+    add_library(nwchem INTERFACE)
 endif()


### PR DESCRIPTION
**Is this pull request associated with an issue(s)?**
No

**Description**
Since FriendZone is right now pure Python, there was no CMake target for it. While there is a plan to add Python library support to CMaize, it does not exist yet. Without a target to look for NWChemEx's build system can't find FriendZone.

This PR creates dummy CMake targets for FriendZone and NWChem. It should be noted, that this workaround will only work when FriendZone is included via `FetchContent`, i.e., if you try to pre-install FriendZone this PR won't make that work. Ultimately, the motivation for this PR is to make it so the NWChemEx repo will work as a meta package (in which case it's assumed FriendZone is being pulled in via `FetchContent`).

**TODOs**
None r2g.
