### PR TITLE
Adds a module for bootstrapping off of QCElemental's from_data

### DIFF
--- a/src/python/friendzone/__init__.py
+++ b/src/python/friendzone/__init__.py
@@ -13,6 +13,7 @@
 # limitations under the License.
 
 from .nwx2nwchem import load_nwchem_modules
+from .nwx2qcelemental import load_qcelemental_modules
 
 
 def load_modules(mm):
@@ -20,8 +21,9 @@ def load_modules(mm):
     calls the various friend specific module loading functions, including:
 
     *  `load_nwchem_modules`
-    
+
     :param mm: The ModuleManager that the all Modules will be loaded into.
     :type mm: pluginplay.ModuleManager
     """
     load_nwchem_modules(mm)
+    load_qcelemental_modules(mm)

--- a/src/python/friendzone/nwx2qcelemental/__init__.py
+++ b/src/python/friendzone/nwx2qcelemental/__init__.py
@@ -1,0 +1,47 @@
+# Copyright 2024 NWChemEx
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import pluginplay as pp
+from simde import MoleculeFromString
+from ..nwx2qcelemental.chemical_system_conversions import qc_mol2molecule
+import qcelemental
+
+
+class SystemViaMolSSI(pp.ModuleBase):
+
+    def __init__(self):
+        pp.ModuleBase.__init__(self)
+        self.satisfies_property_type(MoleculeFromString())
+        self.description("""
+            Creates an NWChemEx ChemicalSystem by going through MolSSI's
+            string parser.
+            """)
+
+    def run_(self, inputs, submods):
+        pt = MoleculeFromString()
+        mol_str, = pt.unwrap_inputs(inputs)
+        mol = qc_mol2molecule(qcelemental.models.Molecule.from_data(mol_str))
+
+        rv = self.results()
+        return pt.wrap_results(rv, mol)
+
+
+def load_qcelemental_modules(mm):
+    """Loads the collection of modules that wrap QCElemental calls.
+
+    :param mm: The ModuleManager that the NWChem Modules will be loaded into.
+    :type mm: pluginplay.ModuleManager
+    """
+
+    mm.add_module('ChemicalSystem via QCElemental', SystemViaMolSSI())

--- a/src/python/friendzone/nwx2qcelemental/chemical_system_conversions.py
+++ b/src/python/friendzone/nwx2qcelemental/chemical_system_conversions.py
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 import qcelemental as qcel
-from chemist import Atom, Molecule
+from chemist import Molecule, Nuclei, Nucleus
 
 
 def chemical_system2qc_mol(chem_sys):
@@ -58,22 +58,20 @@ def qc_mol2molecule(qc_mol):
 
     """
 
-    mol = chemist.Molecule(qc_mol.molecular_charge,
-                           qc_mol.molecular_multiplicity)
-
     n_atoms = len(qc_mol.atom_labels)
+    nuclei = Nuclei()
+    mass_conversion = qcel.constants.conversion_factor("dalton", "au_mass")
 
     for i in range(n_atoms):
-        sym = qc_mol.atom_labels[i]
+        sym = qc_mol.symbols[i]
         Zi = qc_mol.atomic_numbers[i]
-        mass = qc_mol.masses[i]
-        i3 = 3 * i
-        x = qc_mol.geometry[i3]
-        y = qc_mol.geometry[i3 + 1]
-        z = qc_mol.geometry[i3 + 2]
+        mass = qc_mol.masses[i] * mass_conversion
+        x = qc_mol.geometry[i][0]
+        y = qc_mol.geometry[i][1]
+        z = qc_mol.geometry[i][2]
         nuclear_charge = float(Zi)
-        nelectrons = Zi
-        ai = chemist.Atom(sym, Zi, mass, x, y, z, nuclear_charge, nelectrons)
-        mol.push_back(ai)
+        nuclei.push_back(Nucleus(sym, Zi, mass, x, y, z, nuclear_charge))
 
-    return mol
+    charge = int(qc_mol.molecular_charge)
+    multiplicity = int(qc_mol.molecular_multiplicity)
+    return Molecule(charge, multiplicity, nuclei)

--- a/src/python/friendzone/nwx2qcelemental/chemical_system_conversions.py
+++ b/src/python/friendzone/nwx2qcelemental/chemical_system_conversions.py
@@ -13,6 +13,7 @@
 # limitations under the License.
 
 import qcelemental as qcel
+from chemist import Atom, Molecule
 
 
 def chemical_system2qc_mol(chem_sys):
@@ -43,3 +44,36 @@ def chemical_system2qc_mol(chem_sys):
         z = str(atom_i.z * au2ang)
         out += symbol + " " + x + " " + y + " " + z + "\n"
     return qcel.models.Molecule.from_data(out)
+
+
+def qc_mol2molecule(qc_mol):
+    """ Converts a QCElemental.Molecule object to a Chemist.Molecule object.
+
+
+    .. note::
+
+       QCElemental's Molecule class contains extra information that
+       Chemist's Molecule class does not. At present this function ignores all
+       extra information.
+
+    """
+
+    mol = chemist.Molecule(qc_mol.molecular_charge,
+                           qc_mol.molecular_multiplicity)
+
+    n_atoms = len(qc_mol.atom_labels)
+
+    for i in range(n_atoms):
+        sym = qc_mol.atom_labels[i]
+        Zi = qc_mol.atomic_numbers[i]
+        mass = qc_mol.masses[i]
+        i3 = 3 * i
+        x = qc_mol.geometry[i3]
+        y = qc_mol.geometry[i3 + 1]
+        z = qc_mol.geometry[i3 + 2]
+        nuclear_charge = float(Zi)
+        nelectrons = Zi
+        ai = chemist.Atom(sym, Zi, mass, x, y, z, nuclear_charge, nelectrons)
+        mol.push_back(ai)
+
+    return mol

--- a/src/python/friendzone/nwx2qcengine/call_qcengine.py
+++ b/src/python/friendzone/nwx2qcengine/call_qcengine.py
@@ -14,7 +14,7 @@
 
 import qcengine as qcng
 import qcelemental as qcel
-from .chemical_system2qc_mol import chemical_system2qc_mol
+from ..nwx2qcelemental.chemical_system_conversions import chemical_system2qc_mol
 from .pt2driver import pt2driver
 
 

--- a/tests/python/unit_tests/compare_molecules.py
+++ b/tests/python/unit_tests/compare_molecules.py
@@ -1,0 +1,28 @@
+# Copyright 2024 NWChemEx
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+
+def compare_molecules(self, lhs, rhs):
+    self.assertEqual(lhs.charge(), rhs.charge())
+    self.assertEqual(lhs.multiplicity(), rhs.multiplicity())
+    self.assertEqual(lhs.size(), rhs.size())
+    for i in range(lhs.size()):
+        lhs_i = lhs.at(i)
+        rhs_i = rhs.at(i)
+        self.assertEqual(lhs_i.name, rhs_i.name)
+        self.assertEqual(lhs_i.Z, rhs_i.Z)
+        self.assertAlmostEqual(lhs_i.mass, rhs_i.mass)
+        self.assertAlmostEqual(lhs_i.x, rhs_i.x)
+        self.assertAlmostEqual(lhs_i.y, rhs_i.y)
+        self.assertAlmostEqual(lhs_i.z, rhs_i.z)

--- a/tests/python/unit_tests/molecules.py
+++ b/tests/python/unit_tests/molecules.py
@@ -17,7 +17,7 @@ from chemist import Atom, Molecule, ChemicalSystem
 
 def make_h2():
     mol = Molecule()
-    mol.push_back(Atom('H', 1, 1839.0, 0.0, 0.0, 0.0))
-    mol.push_back(Atom('H', 1, 1839.0, 0.0, 0.0, 1.68185))
+    mol.push_back(Atom('H', 1, 1837.15264648179, 0.0, 0.0, 0.0))
+    mol.push_back(Atom('H', 1, 1837.15264648179, 0.0, 0.0, 1.68185))
 
     return ChemicalSystem(mol)

--- a/tests/python/unit_tests/nwx2qcelemental/__init__.py
+++ b/tests/python/unit_tests/nwx2qcelemental/__init__.py
@@ -1,0 +1,13 @@
+# Copyright 2024 NWChemEx-Project
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.

--- a/tests/python/unit_tests/nwx2qcelemental/test_chemical_system_conversions.py
+++ b/tests/python/unit_tests/nwx2qcelemental/test_chemical_system_conversions.py
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from friendzone.nwx2qcengine.chemical_system2qc_mol import *
+from friendzone.nwx2qceelemental.chemical_system_conversions import *
 from molecules import make_h2
 import qcelemental as qcel
 import unittest
@@ -27,3 +27,12 @@ class TestChemicalSystem2QC(unittest.TestCase):
         h2_as_str = "H 0.0 0.0 0.0\nH 0.0 0.0 0.8899966917653396"
         corr = qcel.models.Molecule.from_data(h2_as_str)
         self.assertEqual(qcel_mol, corr)
+
+
+class TestQCMol2Molecule(unittest.TestCase):
+
+    def test_h2(self):
+        corr = make_h2()
+        h2_as_str = "H 0.0 0.0 0.0\nH 0.0 0.0 0.8899966917653396"
+        mol = qcel.models.Molecule.from_data(h2_as_str)
+        self.assertEqual(qc_mol2molecule(mol), corr)

--- a/tests/python/unit_tests/nwx2qcelemental/test_chemical_system_conversions.py
+++ b/tests/python/unit_tests/nwx2qcelemental/test_chemical_system_conversions.py
@@ -12,10 +12,11 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from friendzone.nwx2qceelemental.chemical_system_conversions import *
+from friendzone.nwx2qcelemental.chemical_system_conversions import *
 from molecules import make_h2
 import qcelemental as qcel
 import unittest
+from compare_molecules import compare_molecules
 
 
 class TestChemicalSystem2QC(unittest.TestCase):
@@ -32,7 +33,8 @@ class TestChemicalSystem2QC(unittest.TestCase):
 class TestQCMol2Molecule(unittest.TestCase):
 
     def test_h2(self):
-        corr = make_h2()
+        corr = make_h2().molecule
         h2_as_str = "H 0.0 0.0 0.0\nH 0.0 0.0 0.8899966917653396"
         mol = qcel.models.Molecule.from_data(h2_as_str)
-        self.assertEqual(qc_mol2molecule(mol), corr)
+        result = qc_mol2molecule(mol)
+        compare_molecules(self, result, corr)

--- a/tests/python/unit_tests/nwx2qcelemental/test_system_via_molssi.py
+++ b/tests/python/unit_tests/nwx2qcelemental/test_system_via_molssi.py
@@ -1,0 +1,35 @@
+# Copyright 2024 NWChemEx-Project
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from pluginplay import ModuleManager
+from friendzone import load_modules
+from simde import MoleculeFromString
+from molecules import make_h2
+from compare_molecules import compare_molecules
+import unittest
+
+
+class TestSystemViaMolSSI(unittest.TestCase):
+
+    def test_h2(self):
+        corr = make_h2()
+        mol_str = 'units a.u.\nH 0.0 0.0 0.0\nH 0.0 0.0 1.68185'
+        mol = self.mm.run_as(self.pt, 'ChemicalSystem via QCElemental',
+                             mol_str)
+        compare_molecules(self, corr.molecule, mol)
+
+    def setUp(self):
+        self.mm = ModuleManager()
+        load_modules(self.mm)
+        self.pt = MoleculeFromString()


### PR DESCRIPTION
**Is this pull request associated with an issue(s)?**
No

**Description**
QCElemental has the ability to take a traditional XYZ string and create an instance of its Molecule object. This PR adds the ability to go from a QCElemental Molecule object to a chemist Molecule and introduces a module which will go from a string, to a QCElemental Molecule, to a chemist Molecule. 

While going from a string to a chemist Molecule would be more efficient, doing it this way allows us to bootstrap off of QCElemental. If this is found to be too inefficient others can write their own modules.

**TODOs**
None. R2g.
