### PR TITLE
Module Return Types

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -91,7 +91,7 @@ if("${BUILD_TESTING}")
     nwx_pybind11_tests(
         py_${PROJECT_NAME}
         "${PYTHON_TEST_DIR}/unit_tests/test_friendzone.py"
-        SUBMODULES simde chemist pluginplay parallelzone
+        SUBMODULES simde chemist pluginplay parallelzone tensorwrapper
     )
 endif()
 

--- a/src/python/friendzone/nwx2ase/nwchem_via_ase.py
+++ b/src/python/friendzone/nwx2ase/nwchem_via_ase.py
@@ -19,6 +19,8 @@ from .chemical_system_conversions import chemical_system2atoms
 from ase.calculators.nwchem import NWChem
 from ase import units
 import uuid
+import numpy as np
+import tensorwrapper as tw
 
 
 class NWChemEnergyViaASE(pp.ModuleBase):
@@ -44,9 +46,10 @@ class NWChemEnergyViaASE(pp.ModuleBase):
                             task='Energy',
                             label=str(uuid.uuid4()))
         egy = atoms.get_potential_energy()
+        egy = tw.Tensor(np.array(egy / units.Hartree))
 
         rv = self.results()
-        return pt.wrap_results(rv, egy / units.Hartree)
+        return pt.wrap_results(rv, egy)
 
 
 class NWChemGradientViaASE(pp.ModuleBase):
@@ -79,6 +82,7 @@ class NWChemGradientViaASE(pp.ModuleBase):
         au2eV = units.Hartree  # Hartree to eV conversion
         au2ang = units.Bohr  # Bohr to Angstrom conversion
         # We get the FORCE back NOT the gradient (i.e., need to multiply by -1)
+        egy = tw.Tensor(np.array(egy / au2eV))
         augrad = [-1.0 * x / (au2eV / au2ang) for x in grad]
-        rv = TotalEnergy().wrap_results(rv, egy / au2eV)
+        rv = TotalEnergy().wrap_results(rv, egy)
         return pt.wrap_results(rv, augrad)

--- a/src/python/friendzone/nwx2qcengine/__init__.py
+++ b/src/python/friendzone/nwx2qcengine/__init__.py
@@ -17,6 +17,8 @@ import pluginplay as pp
 from simde import TotalEnergy, EnergyNuclearGradientStdVectorD
 from .call_qcengine import call_qcengine
 from ..utils.unwrap_inputs import unwrap_inputs
+import numpy as np
+import tensorwrapper as tw
 
 
 def _run_impl(driver, inputs, rv, runtime):
@@ -52,7 +54,8 @@ def _run_impl(driver, inputs, rv, runtime):
         grad = outputs['gradient'].flatten().tolist()
         rv = pts[driver].wrap_results(rv, grad)
 
-    return pts['energy'].wrap_results(rv, outputs['energy'])
+    egy = tw.Tensor(np.array(outputs['energy']))
+    return pts['energy'].wrap_results(rv, egy)
 
 
 class QCEngineEnergy(pp.ModuleBase):

--- a/tests/python/unit_tests/nwx2ase/test_nwchem_via_ase.py
+++ b/tests/python/unit_tests/nwx2ase/test_nwchem_via_ase.py
@@ -17,6 +17,7 @@ from friendzone import friends, load_modules
 from simde import TotalEnergy, EnergyNuclearGradientStdVectorD
 from molecules import make_h2
 import unittest
+import numpy as np
 
 
 class TestNWChemViaASE(unittest.TestCase):
@@ -26,7 +27,7 @@ class TestNWChemViaASE(unittest.TestCase):
         key = 'ASE(NWChem) : SCF'
         self.mm.change_input(key, 'basis set', 'sto-3g')
         egy = self.mm.run_as(TotalEnergy(), key, mol)
-        self.assertAlmostEqual(egy, -1.094184522864, places=5)
+        self.assertAlmostEqual(np.array(egy), -1.094184522864, places=5)
 
     def test_scf_gradient(self):
         mol = make_h2()
@@ -46,21 +47,21 @@ class TestNWChemViaASE(unittest.TestCase):
         key = 'ASE(NWChem) : MP2'
         self.mm.change_input(key, 'basis set', 'sto-3g')
         egy = self.mm.run_as(TotalEnergy(), key, mol)
-        self.assertAlmostEqual(egy, -1.111247857166, places=5)
+        self.assertAlmostEqual(np.array(egy), -1.111247857166, places=5)
 
     def test_ccsd(self):
         mol = make_h2()
         key = 'ASE(NWChem) : CCSD'
         self.mm.change_input(key, 'basis set', 'sto-3g')
         egy = self.mm.run_as(TotalEnergy(), key, mol)
-        self.assertAlmostEqual(egy, -1.122251361965036, places=4)
+        self.assertAlmostEqual(np.array(egy), -1.122251361965036, places=4)
 
     def test_ccsd_t(self):
         mol = make_h2()
         key = 'ASE(NWChem) : CCSD(T)'
         self.mm.change_input(key, 'basis set', 'sto-3g')
         egy = self.mm.run_as(TotalEnergy(), key, mol)
-        self.assertAlmostEqual(egy, -1.122251361965036, places=4)
+        self.assertAlmostEqual(np.array(egy), -1.122251361965036, places=4)
 
     def setUp(self):
         if not friends.is_friend_enabled('nwchem'):

--- a/tests/python/unit_tests/nwx2qcengine/test_nwchem.py
+++ b/tests/python/unit_tests/nwx2qcengine/test_nwchem.py
@@ -17,6 +17,7 @@ from friendzone import friends, load_modules
 from simde import TotalEnergy, EnergyNuclearGradientStdVectorD
 from molecules import make_h2
 import unittest
+import numpy as np
 
 
 class TestNWChem(unittest.TestCase):
@@ -26,7 +27,7 @@ class TestNWChem(unittest.TestCase):
         key = 'NWChem : SCF'
         self.mm.change_input(key, 'basis set', 'sto-3g')
         egy = self.mm.run_as(TotalEnergy(), key, mol)
-        self.assertAlmostEqual(egy, -1.094184522864, places=5)
+        self.assertAlmostEqual(np.array(egy), -1.094184522864, places=5)
 
     def test_scf_gradient(self):
         mol = make_h2()
@@ -46,21 +47,21 @@ class TestNWChem(unittest.TestCase):
         key = 'NWChem : MP2'
         self.mm.change_input(key, 'basis set', 'sto-3g')
         egy = self.mm.run_as(TotalEnergy(), key, mol)
-        self.assertAlmostEqual(egy, -1.111247857166, places=5)
+        self.assertAlmostEqual(np.array(egy), -1.111247857166, places=5)
 
     def test_ccsd(self):
         mol = make_h2()
         key = 'NWChem : CCSD'
         self.mm.change_input(key, 'basis set', 'sto-3g')
         egy = self.mm.run_as(TotalEnergy(), key, mol)
-        self.assertAlmostEqual(egy, -1.122251361965036, places=4)
+        self.assertAlmostEqual(np.array(egy), -1.122251361965036, places=4)
 
     def test_ccsd_t(self):
         mol = make_h2()
         key = 'NWChem : CCSD(T)'
         self.mm.change_input(key, 'basis set', 'sto-3g')
         egy = self.mm.run_as(TotalEnergy(), key, mol)
-        self.assertAlmostEqual(egy, -1.122251361965036, places=4)
+        self.assertAlmostEqual(np.array(egy), -1.122251361965036, places=4)
 
     def setUp(self):
         if not friends.is_friend_enabled('nwchem'):


### PR DESCRIPTION
**Description**
Changes in SimDE and TensorWrapper necessitated updates for several modules to return `tensorwrapper.Tensor`s, and then to correctly handle these altered types in the tests.