### PR TITLE
change to unwrap_inputs round to 16 decimal places was added

### DIFF
--- a/src/python/friendzone/utils/unwrap_inputs.py
+++ b/src/python/friendzone/utils/unwrap_inputs.py
@@ -16,7 +16,6 @@ from simde import TotalEnergy, EnergyNuclearGradientStdVectorD
 import numpy as np
 
 
-
 def _compare_mol_and_point(mol, points, atol=1e-12, rtol=0.0):
     """
     Compare the 3D nuclear coordinates of a Molecule and a PointSet.


### PR DESCRIPTION
**Is this pull request associated with an issue(s)?**
Yes, based on an error representation I think between python and c++ of the number zero.


Please list issues associated with this pull request, including [closing words](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)
as appropriate.

 In the communication between python and c++ it looks like the number zero changes from 0.0 to 4.423185485e-315.  This was observed for the coordinates of the (0.0, 0.0, 0.0) vector. So instead of the zero vector it was show the vector:

([4.423185485e-315, 4.42424859e-315, 4.41864936e-315 )

**Description**
Keeps the zero vector as it should by using round to 16 decimal places in:

'
def _compare_mol_and_point(mol, points):
    """This function is essentially a work around for the comparisons not being
    exposed to Python.
    """
    if mol.size() != points.size():
        return False

    for i in range(mol.size()):
        atom_i = mol.at(i)
        point_i = points.at(i)

        for j in range(3):
            if round(atom_i.coord(j),16) != round(point_i.coord(j),16):  <--- Here the round function was used
                return False

    return True
'

**TODOs**
I think there is nothing else to do.
