### PR TITLE
Remove SPHINXOPTS hardcode

### DIFF
--- a/docs/Makefile
+++ b/docs/Makefile
@@ -2,7 +2,7 @@
 #
 
 # You can set these variables from the command line.
-SPHINXOPTS    = -W --keep-going -n
+SPHINXOPTS    =
 SPHINXBUILD   = sphinx-build
 SPHINXPROJ    = friendzone
 SOURCEDIR     = source


### PR DESCRIPTION
**Is this pull request associated with an issue(s)?**
No.

**Description**
At some point, the flags to make Sphinx fail on warnings got hardcoded into the docs' Makefile. This removes them.