### PR TITLE
Fix invalid YAML in merge.yaml (dangling empty with: block)

### DIFF
--- a/.github/workflows/merge.yaml
+++ b/.github/workflows/merge.yaml
@@ -43,7 +43,6 @@ jobs:
     steps:
       - name: Build PyPI Distribution
         uses: NWChemEx/.github/.github/actions/build_pypi_dist@master
-        with:
 
       - name: Publish to PyPI
         uses: pypa/gh-action-pypi-publish@release/v1


### PR DESCRIPTION
merge.yaml's `deploy_to_pypi` job failed to parse at all after #34 merged (0 jobs ran) because deleting the TestPyPI `extra_index_url` line left an empty `with:` mapping. Removes the dangling key.